### PR TITLE
fix: Update workflow to use CACHIX_AUTH_TOKEN secret

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -46,7 +46,7 @@ Cachix is a binary cache service for Nix that significantly speeds up builds by 
 ### Configuration
 
 **Required Secret:**
-- `CACHIX_KEY` - Authentication token for the Cachix `cosmic` cache
+- `CACHIX_AUTH_TOKEN` - Authentication token for the Cachix `cosmic` cache
   - Location: Repository Settings → Secrets and Variables → Actions
   - This should be your Cachix auth token (from https://app.cachix.org/personal-auth-tokens)
   - For security, use a per-cache token (not a personal token)
@@ -87,13 +87,13 @@ nix develop
 
 **Cache not being used:**
 - Verify the cache name is correct (`cosmic`)
-- Check that the secret `CACHIX_KEY` is set correctly
+- Check that the secret `CACHIX_AUTH_TOKEN` is set correctly
 - Ensure your Nix version supports flakes
 
 **Packages not being pushed:**
 - Only happens on `main` branch (not PRs)
 - Check workflow logs for push confirmation
-- Verify the auth token has write permissions
+- Verify the `CACHIX_AUTH_TOKEN` has write permissions to your cache
 
 **Build still slow:**
 - First build after changes will be slow (building from source)
@@ -109,7 +109,7 @@ When creating new workflows:
    - uses: cachix/cachix-action@v14
      with:
        name: cosmic
-       authToken: '${{ secrets.CACHIX_KEY }}'
+       authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
        skipPush: true  # or false for main branch
    ```
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,9 +26,9 @@ jobs:
         uses: cachix/cachix-action@v14
         with:
           name: cosmic
-          # Auth token for pushing to Cachix (using CACHIX_KEY secret)
+          # Auth token for pushing to Cachix
           # Note: Only pushes on main branch, PRs use read-only mode
-          authToken: '${{ secrets.CACHIX_KEY }}'
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
           skipPush: ${{ github.ref != 'refs/heads/main' }}
       
       - name: Check Nix flake
@@ -66,7 +66,7 @@ jobs:
         uses: cachix/cachix-action@v14
         with:
           name: cosmic
-          authToken: '${{ secrets.CACHIX_KEY }}'
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
           skipPush: true  # Read-only for this job
 
       - name: Check formatting
@@ -91,7 +91,7 @@ jobs:
         uses: cachix/cachix-action@v14
         with:
           name: cosmic
-          authToken: '${{ secrets.CACHIX_KEY }}'
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
           skipPush: true  # Read-only for this job
 
       - name: Run Clippy


### PR DESCRIPTION
## Problem

The current workflow uses `CACHIX_KEY` as the secret name, but the standard Cachix convention is `CACHIX_AUTH_TOKEN`. Additionally, we're getting 401 Unauthorized errors when trying to push to Cachix.

## Changes

- ✅ Changed secret reference from `CACHIX_KEY` to `CACHIX_AUTH_TOKEN` in all three jobs
- ✅ Updated documentation to reflect correct secret name
- ✅ Follows standard Cachix naming convention

## Next Steps Required

After merging this PR, you need to:

### 1. Rename GitHub Secret

Go to: **Repository Settings → Secrets and Variables → Actions**

- Delete or rename `CACHIX_KEY` to `CACHIX_AUTH_TOKEN`
- Or create new secret `CACHIX_AUTH_TOKEN` with your Cachix auth token

### 2. Verify Cache Name

The workflow is configured to use cache name: **`cosmic`**

Make sure:
- This cache exists in your Cachix account at https://app.cachix.org/cache
- Your auth token has **write permissions** to this cache
- If you don't have a cache named `cosmic`, either:
  - Create it in Cachix, OR
  - Update the workflow to use your existing cache name

### 3. Get Your Auth Token

If you need to create/update the token:
1. Go to https://app.cachix.org/personal-auth-tokens
2. Create a **per-cache token** for your cache (more secure than personal token)
3. Copy the token value
4. Add it as `CACHIX_AUTH_TOKEN` in GitHub secrets

## Testing

Once the secret is set correctly, the next push to main will:
- Download packages from the cache (if available)
- Build the NixOS package
- Push newly built packages back to Cachix

---

🤖 Generated with Claude Code